### PR TITLE
Fix spelling error in idealo.de use-case

### DIFF
--- a/CaseStudies.md
+++ b/CaseStudies.md
@@ -227,7 +227,7 @@ as the load balancer for reads.
 [idealo.de](https://www.idealo.de/) is the leading price comparison website in Germany. We use Prometheus for metrics on our container platform.
 When we introduced Prometheus at idealo we started with m3db as our longterm storage. In our setup, m3db was quite unstable and consumed a lot of resources.
 
-VictoriaMetrics in poroduction is very stable for us and uses only a fraction of the resources even though we also increased our retention period from 1 month to 13 months.
+VictoriaMetrics in production is very stable for us and uses only a fraction of the resources even though we also increased our retention period from 1 month to 13 months.
 
 Numbers:
 


### PR DESCRIPTION
(this does not seem to be the canonical source, but I suppose you can fix it at the source)